### PR TITLE
fix and compile regex with babel

### DIFF
--- a/build/js/ABPLibxml.js
+++ b/build/js/ABPLibxml.js
@@ -26,7 +26,7 @@ function CommentLoader(url, xcm, callback) {
                 cm.load(BilibiliParser(f));
                 callback();
             } else {
-                var standarizedXML = xmlhttp.responseXML == null ? (new window.DOMParser()).parseFromString(xmlhttp.responseText.replace(/[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF]/g,""), "text/xml") : xmlhttp.responseXML;
+                var standarizedXML = xmlhttp.responseXML == null ? (new window.DOMParser()).parseFromString(xmlhttp.responseText.replace(/(?:[\0-\x08\x0B\f\x0E-\x1F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])/g, ""), "text/xml") : xmlhttp.responseXML;
                 cm.load(BilibiliParser(standarizedXML));
                 //console.log(standarizedXML);
                 callback();


### PR DESCRIPTION
the regex `[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF]/g` should be written as 
`/[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}]/ug` to be correctly recognized by javascript, and compiled with babel for compatibility with old versions of javascript